### PR TITLE
Make zsim with Pin 2.x run on Linux kernel 4

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -48,6 +48,10 @@ def buildSim(cppFlags, dir, type, pgo=None):
     # NOTE (dsm 16 Apr 2015): Update flags code to support Pin 2.14 while retaining backwards compatibility
     env["CPPFLAGS"] += " -g -std=c++0x -Wall -Wno-unknown-pragmas -fomit-frame-pointer -fno-stack-protector"
     env["CPPFLAGS"] += " -MMD -DBIGARRAY_MULTIPLIER=1 -DUSING_XED -DTARGET_IA32E -DHOST_IA32E -fPIC -DTARGET_LINUX"
+    # NOTE: (mgao Jan 2017): Pin 2.14 requires ABI version of 1002, while gcc-5 and later bumps the API version.
+    # Switch to gcc-4.x by using -fabi-version=2
+    # FIXME(mgao): update this when upgraded to Pin 3.x
+    env["CPPFLAGS"] += " -fabi-version=2  -D_GLIBCXX_USE_CXX11_ABI=0"
 
     # Pin 2.12+ kits have changed the layout of includes, detect whether we need
     # source/include/ or source/include/pin/

--- a/SConstruct
+++ b/SConstruct
@@ -143,7 +143,16 @@ def buildSim(cppFlags, dir, type, pgo=None):
     env["CPPPATH"] += ["."]
 
     # HDF5
-    env["PINLIBS"] += ["hdf5", "hdf5_hl"]
+    conf = Configure(Environment(), conf_dir=joinpath(buildDir, ".sconf_temp"), log_file=joinpath(buildDir, "sconf.log"))
+    if conf.CheckLib('hdf5') and conf.CheckLib('hdf5_hl'):
+        env["PINLIBS"] += ["hdf5", "hdf5_hl"]
+    elif conf.CheckLib('hdf5_serial') and conf.CheckLib('hdf5_serial_hl'):
+        # Serial version, in Ubuntu 15.04 and later.
+        env["PINLIBS"] += ["hdf5_serial", "hdf5_serial_hl"]
+        env["CPPFLAGS"] += ' -DHDF5INCPREFIX="hdf5/serial/"'
+    else:
+       print "ERROR: You need to install libhdf5 in the system"
+       sys.exit(1)
 
     # Harness needs these defined
     env["CPPFLAGS"] += ' -DPIN_PATH="' + joinpath(PINPATH, "intel64/bin/pinbin") + '" '

--- a/src/SConscript
+++ b/src/SConscript
@@ -35,7 +35,11 @@ libEnv.SharedLibrary("zsim.so", libSrcs)
 
 # Build tracing utilities (need hdf5 & dynamic linking)
 traceEnv = env.Clone()
-traceEnv["LIBS"] += ["hdf5", "hdf5_hl"]
+if "hdf5" in traceEnv["PINLIBS"]:
+    traceEnv["LIBS"] += ["hdf5", "hdf5_hl"]
+else:
+    assert "hdf5_serial" in traceEnv["PINLIBS"]
+    traceEnv["LIBS"] += ["hdf5_serial", "hdf5_serial_hl"]
 traceEnv["OBJSUFFIX"] += "t"
 traceEnv.Program("dumptrace", ["dumptrace.cpp", "access_tracing.cpp", "memory_hierarchy.cpp"] + commonSrcs)
 traceEnv.Program("sorttrace", ["sorttrace.cpp", "access_tracing.cpp"] + commonSrcs)

--- a/src/access_tracing.cpp
+++ b/src/access_tracing.cpp
@@ -25,8 +25,18 @@
 
 #include "access_tracing.h"
 #include "bithacks.h"
+
+#define _STR(x) #x
+#define STR(x) _STR(x)
+#ifdef HDF5INCPREFIX
+#include STR(HDF5INCPREFIX/hdf5.h)
+#include STR(HDF5INCPREFIX/hdf5_hl.h)
+#else
 #include <hdf5.h>
 #include <hdf5_hl.h>
+#endif
+#undef STR
+#undef _STR
 
 #define PT_CHUNKSIZE (1024*256u)  // 256K records (~6MB)
 

--- a/src/access_tracing.cpp
+++ b/src/access_tracing.cpp
@@ -26,6 +26,8 @@
 #include "access_tracing.h"
 #include "bithacks.h"
 
+// Concatenate HDF5 header path prefix with the header file names, because
+// Ubuntu 15.04 and later change the HDF5 header path.
 #define _STR(x) #x
 #define STR(x) _STR(x)
 #ifdef HDF5INCPREFIX

--- a/src/hdf5_stats.cpp
+++ b/src/hdf5_stats.cpp
@@ -23,6 +23,8 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+// Concatenate HDF5 header path prefix with the header file names, because
+// Ubuntu 15.04 and later change the HDF5 header path.
 #define _STR(x) #x
 #define STR(x) _STR(x)
 #ifdef HDF5INCPREFIX

--- a/src/hdf5_stats.cpp
+++ b/src/hdf5_stats.cpp
@@ -23,9 +23,19 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <fstream>
+#define _STR(x) #x
+#define STR(x) _STR(x)
+#ifdef HDF5INCPREFIX
+#include STR(HDF5INCPREFIX/hdf5.h)
+#include STR(HDF5INCPREFIX/hdf5_hl.h)
+#else
 #include <hdf5.h>
 #include <hdf5_hl.h>
+#endif
+#undef STR
+#undef _STR
+
+#include <fstream>
 #include <iostream>
 #include <vector>
 #include "galloc.h"

--- a/src/pin_cmd.cpp
+++ b/src/pin_cmd.cpp
@@ -24,11 +24,14 @@
  */
 
 #include "pin_cmd.h"
+#include <algorithm>
 #include <iostream>
+#include <linux/version.h>
 #include <sstream>
 #include <string>
 #include <wordexp.h> //for posix-shell command expansion
 #include "config.h"
+#include "pin.H"
 
 //Funky macro expansion stuff
 #define QUOTED_(x) #x
@@ -64,6 +67,14 @@ PinCmd::PinCmd(Config* conf, const char* configFile, const char* outputDir, uint
         args.push_back(g_string(p.we_wordv[i]));
     }
     wordfree(&p);
+
+    if (PIN_PRODUCT_VERSION_MAJOR <= 2 && LINUX_VERSION_CODE >= KERNEL_VERSION(4,0,0)
+            && std::find(args.begin(), args.end(), "-injection") == args.end()) {
+        // FIXME(mgao): hack to bypass kernel version check in Pin 2.x.
+        // Parent injection.
+        args.push_back("-injection");
+        args.push_back("parent");
+    }
 
     //Load tool
     args.push_back("-t");


### PR DESCRIPTION
While zsim does not support Pin 3.0, we can make it run with Pin 2.x on newer Linux.

Fixes:

Resolve hdf5 lib path in Ubuntu 15.04 and later.
Change Pin injection mode only when using Pin 2.x with kernel 4 and later.
Match ABI of gcc 5 and later with Pin.