### PR TITLE
Fixes local install when checking availability of HDF5

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -147,7 +147,7 @@ def buildSim(cppFlags, dir, type, pgo=None):
     env["CPPPATH"] += ["."]
 
     # HDF5
-    conf = Configure(Environment(), conf_dir=joinpath(buildDir, ".sconf_temp"), log_file=joinpath(buildDir, "sconf.log"))
+    conf = Configure(Environment(ENV = os.environ), conf_dir=joinpath(buildDir, ".sconf_temp"), log_file=joinpath(buildDir, "sconf.log"))
     if conf.CheckLib('hdf5') and conf.CheckLib('hdf5_hl'):
         env["PINLIBS"] += ["hdf5", "hdf5_hl"]
     elif conf.CheckLib('hdf5_serial') and conf.CheckLib('hdf5_serial_hl'):


### PR DESCRIPTION
Fix the SConstruct.
Currently, the SConstruct doesn't work if hdf5 is installed locally.
Supply the os.environ when constructing the Environment to let scons recognize the locally installed hdf5
